### PR TITLE
inffas32.asm struct/enum binding to zlib 1.2.9

### DIFF
--- a/contrib/masmx86/inffas32.asm
+++ b/contrib/masmx86/inffas32.asm
@@ -28,28 +28,24 @@
 ;   compile with command line option
 ;   ml  /coff /Zi /c /Flinffas32.lst inffas32.asm
 
-;   if you define NO_GZIP (see inflate.h), compile with
-;   ml  /coff /Zi /c /Flinffas32.lst /DNO_GUNZIP inffas32.asm
-
-
 ; zlib122sup is 0 fort zlib 1.2.2.1 and lower
 ; zlib122sup is 8 fort zlib 1.2.2.2 and more (with addition of dmax and head
 ;        in inflate_state in inflate.h)
 zlib1222sup      equ    8
 
+; zlib129sup is 0 fort zlib 1.2.8 and lower
+; zlib129sup is 4 fort zlib 1.2.9 and more (with addition of z_streamp
+;        in inflate_state in inflate.h)
+zlib129sup       equ    4
 
-IFDEF GUNZIP
-  INFLATE_MODE_TYPE    equ 11
-  INFLATE_MODE_BAD     equ 26
-ELSE
-  IFNDEF NO_GUNZIP
-    INFLATE_MODE_TYPE    equ 11
-    INFLATE_MODE_BAD     equ 26
-  ELSE
-    INFLATE_MODE_TYPE    equ 3
-    INFLATE_MODE_BAD     equ 17
-  ENDIF
-ENDIF
+; zlib129inflate_mode_head is 0 fort zlib 1.2.8 and lower
+; zlib129inflate_mode_head is 16180 fort zlib 1.2.9 and more
+; INFLATE_MODE_BAD enum is 26 fort zlib 1.2.3.3 and lower
+; INFLATE_MODE_BAD enum is 29 fort zlib 1.2.3.4 and more
+zlib129inflate_mode_head equ 16180
+
+  INFLATE_MODE_TYPE    equ (zlib129inflate_mode_head+11)
+  INFLATE_MODE_BAD     equ (zlib129inflate_mode_head+29)
 
 
 ; 75 "inffast.S"
@@ -133,16 +129,16 @@ dd	2147483647
 dd	4294967295
 
 
-mode_state	 equ	0	;/* state->mode	*/
-wsize_state	 equ	(32+zlib1222sup)	;/* state->wsize */
-write_state	 equ	(36+4+zlib1222sup)	;/* state->write */
-window_state	 equ	(40+4+zlib1222sup)	;/* state->window */
-hold_state	 equ	(44+4+zlib1222sup)	;/* state->hold	*/
-bits_state	 equ	(48+4+zlib1222sup)	;/* state->bits	*/
-lencode_state	 equ	(64+4+zlib1222sup)	;/* state->lencode */
-distcode_state	 equ	(68+4+zlib1222sup)	;/* state->distcode */
-lenbits_state	 equ	(72+4+zlib1222sup)	;/* state->lenbits */
-distbits_state	 equ	(76+4+zlib1222sup)	;/* state->distbits */
+mode_state      equ (zlib129sup+0)                  ;/* state->mode	*/
+wsize_state     equ (zlib129sup+32+zlib1222sup)     ;/* state->wsize */
+write_state     equ (zlib129sup+36+4+zlib1222sup)   ;/* state->write */
+window_state    equ (zlib129sup+40+4+zlib1222sup)   ;/* state->window */
+hold_state      equ (zlib129sup+44+4+zlib1222sup)   ;/* state->hold	*/
+bits_state      equ (zlib129sup+48+4+zlib1222sup)   ;/* state->bits	*/
+lencode_state   equ (zlib129sup+64+4+zlib1222sup)   ;/* state->lencode */
+distcode_state  equ (zlib129sup+68+4+zlib1222sup)   ;/* state->distcode */
+lenbits_state   equ (zlib129sup+72+4+zlib1222sup)   ;/* state->lenbits */
+distbits_state  equ (zlib129sup+76+4+zlib1222sup)   ;/* state->distbits */
 
 
 ;;SECTION .text


### PR DESCRIPTION
zlib 1.2.9 added "z_streamp strm" in "struct inflate_state" in
inflate.h, new offset/binding is required

zlib 1.2.9 started "enum inflate_mode" in inflate.h @ 16180

zlib 1.2.3.4 added 3 values in "enum inflate_mode" in inflate.h

zlib 1.2.2.1 removed GUNZIP condition in "struct inflate_state" in
inflate.h, compilation directive was no longer required